### PR TITLE
fix!: remove build hook executed after scaffolding project

### DIFF
--- a/clap-derive/cargo-generate.toml
+++ b/clap-derive/cargo-generate.toml
@@ -7,4 +7,4 @@ exclude = []
 
 [hooks]
 pre = ["hooks/set-variables.rhai"]
-post = ["hooks/build.rhai", "hooks/cleanup.rhai"]
+post = ["hooks/cleanup.rhai"]

--- a/clap-derive/hooks/build.rhai
+++ b/clap-derive/hooks/build.rhai
@@ -1,1 +1,0 @@
-system::command("cargo", ["build"]);


### PR DESCRIPTION
With the previous setup, project generation would fail if the user decides to reject running `cargo build` after generating a project with the `clap-derive` template.

This commit removes this build hook and leaves it up to the user, or rather the rust-analyzer, to manually build a newly generated project.

BREAKING CHANGE: With this change in place, users must not rely on the build hook to run `cargo build` after project generation.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1 <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
